### PR TITLE
Detect moving romb using Mean Filter with background update. Close #48.

### DIFF
--- a/cvclasses16.sln
+++ b/cvclasses16.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lesson1", "lesson1\lesson1.vcxproj", "{82EABB10-C81E-4F60-94F4-1CAADD360388}"
 EndProject
@@ -18,15 +18,12 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{82EABB10-C81E-4F60-94F4-1CAADD360388}.Debug|Win32.ActiveCfg = Debug|Win32
-		{82EABB10-C81E-4F60-94F4-1CAADD360388}.Debug|Win32.Build.0 = Debug|Win32
 		{82EABB10-C81E-4F60-94F4-1CAADD360388}.Release|Win32.ActiveCfg = Release|Win32
 		{82EABB10-C81E-4F60-94F4-1CAADD360388}.Release|Win32.Build.0 = Release|Win32
 		{538E458E-16A0-4BEA-8728-810581319B94}.Debug|Win32.ActiveCfg = Debug|Win32
-		{538E458E-16A0-4BEA-8728-810581319B94}.Debug|Win32.Build.0 = Debug|Win32
 		{538E458E-16A0-4BEA-8728-810581319B94}.Release|Win32.ActiveCfg = Release|Win32
 		{538E458E-16A0-4BEA-8728-810581319B94}.Release|Win32.Build.0 = Release|Win32
 		{DD43A201-2A0B-43EE-B255-AAF6C5B7FD53}.Debug|Win32.ActiveCfg = Debug|Win32
-		{DD43A201-2A0B-43EE-B255-AAF6C5B7FD53}.Debug|Win32.Build.0 = Debug|Win32
 		{DD43A201-2A0B-43EE-B255-AAF6C5B7FD53}.Release|Win32.ActiveCfg = Release|Win32
 		{DD43A201-2A0B-43EE-B255-AAF6C5B7FD53}.Release|Win32.Build.0 = Release|Win32
 		{305A218C-EACE-4C92-8C8A-0438141560C1}.Debug|Win32.ActiveCfg = Debug|Win32

--- a/lesson4/SegmentMotionBase.h
+++ b/lesson4/SegmentMotionBase.h
@@ -1,8 +1,3 @@
-///@File: ISegmentMotion.h
-///@Brief: Contains interface for SegmentMotion classes
-///@Author: Vitaliy Baldeev
-///@Date: 10 October 2015
-
 #pragma once
 
 #include <string>
@@ -20,7 +15,7 @@ class SegmentMotionBase
 {
 public:
     ///@brief Launch demonstration
-    void Run();
+    void Run(const std::string& file_name);
 
         ///@brief Factory method
     static SegmentMotionBase* CreateAlgorithm(std::string& algorithmName);
@@ -44,7 +39,7 @@ protected:
 
     ///@brief Apply the algorthm of background subtraction
     ///@return the result binary image
-    virtual cv::Mat process(cv::VideoCapture& capture) 
+    virtual cv::Mat process(cv::Mat& capture) 
     { 
         return cv::Mat();
     }

--- a/lesson4/SegmentMotionMeanFilter.cpp
+++ b/lesson4/SegmentMotionMeanFilter.cpp
@@ -1,0 +1,59 @@
+#include "SegmentMotionMeanFilter.h"
+
+#include <iostream>
+
+#include "opencv2\videoio.hpp"
+#include "opencv2\imgproc.hpp"
+#include "opencv2\highgui.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+cv::Mat SegmentMotionMeanFilter::process(cv::Mat& currentFrame)
+{
+  cvtColor(currentFrame, currentFrame, CV_RGB2GRAY);
+  updateBackground(currentFrame);
+
+  cv::Mat result = abs(Background - currentFrame.clone());
+  cv::threshold(result, result, m_params.threshold, 255, CV_THRESH_BINARY);
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void SegmentMotionMeanFilter::createGUI()
+{
+  const std::string windowName = GetName();
+  cv::namedWindow(windowName);
+
+  m_params.alpha = 10;
+  m_params.threshold = 10;
+  m_params.num_mean = 30*3;
+  m_params.counter = 0;
+
+  cv::createTrackbar("Threshold", windowName, &m_params.threshold, 255);
+  cv::createTrackbar("Alpha", windowName, &m_params.alpha, 100);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void SegmentMotionMeanFilter::updateBackground(cv::Mat& currentFrame)
+{
+  float scaled_alpha = m_params.alpha * 0.01f;
+
+  if (Background.empty()) {
+    Background = currentFrame.clone();
+    m_params.counter++;
+    return;
+  }
+
+  cv::Mat_<float> floatBackground(Background);
+  cv::Mat_<float> floatCurrentFrame(currentFrame);
+
+  if (m_params.counter >= m_params.num_mean) {
+    floatBackground = (1 - scaled_alpha) * floatBackground + scaled_alpha * floatCurrentFrame;
+  } else {
+    floatBackground = floatBackground * m_params.counter + floatCurrentFrame;
+    m_params.counter++;
+    floatBackground /= m_params.counter;
+  }
+
+  floatBackground.convertTo(Background, CV_8U);
+}

--- a/lesson4/SegmentMotionMeanFilter.h
+++ b/lesson4/SegmentMotionMeanFilter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "SegmentMotionBase.h"
+
+#include "opencv2\core\mat.hpp"
+
+class SegmentMotionMeanFilter : public SegmentMotionBase
+{
+public:
+  SegmentMotionMeanFilter()
+  {
+  }
+
+  virtual std::string GetName() const override
+  {
+    return "SegmentMotionMeanFilter";
+  }
+
+protected:
+  virtual cv::Mat process(cv::Mat& file_name) override;
+
+  virtual void createGUI() override;
+
+  void updateBackground(cv::Mat& currentFrame);
+
+  struct Params
+  {
+    int threshold;
+    int alpha;
+    int num_mean;
+    int counter;
+  };
+
+  Params m_params;
+  cv::Mat Background;
+};

--- a/lesson4/caclMertrick.m
+++ b/lesson4/caclMertrick.m
@@ -1,0 +1,43 @@
+v_res = VideoReader('dd73_res.avi');
+result = VideoReader('result.avi');
+
+Rec = [];
+Prec = [];
+Spec = [];
+FPR = [];
+FNR = [];
+PWC = [];
+Fm = [];
+
+count = 0;
+while hasFrame(v_res) && hasFrame(result)
+    frame_res = rgb2gray(readFrame(v_res));
+    frame_result = rgb2gray(readFrame(result));
+    
+    frame_res = frame_res > 240;
+    frame_result = frame_result > 240;
+    
+    TP = sum(sum(frame_res & frame_result));
+    TN = sum(sum(~frame_res & ~frame_result));
+    FN = sum(sum(~frame_res & frame_result));
+    FP = sum(sum(frame_res & ~frame_result));
+    
+    if count > 30*3
+        Rec = [Rec, TP / (TP + FN)];
+        Prec =[Prec, TP / (TP + FP)];
+        Spec =[Spec, TN / (TN + FP)];
+        FPR =[FPR, FP / (TN + FP)];
+        FNR =[FNR, FN / (TP + FN)];
+        PWC =[PWC, 100 * (FN+FP) / (TP+TN+FP+FN)];
+        Fm =[Fm, 2 * (Prec(end) * Rec(end)) / (Prec(end) + Rec(end))];
+    end
+    count =  count + 1;
+end
+
+figure; hold on; title('Rec'); plot(Rec);
+figure; hold on; title('Prec'); plot(Prec);
+figure; hold on; title('Spec'); plot(Spec);
+figure; hold on; title('FPR'); plot(FPR);
+figure; hold on; title('FNR'); plot(FNR);
+figure; hold on; title('PWC'); plot(PWC);
+figure; hold on; title('Fm'); plot(Fm);

--- a/lesson4/lesson4.vcxproj
+++ b/lesson4/lesson4.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -153,24 +153,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="SegmentMotion1G.cpp" />
     <ClCompile Include="SegmentMotionBase.cpp" />
-    <ClCompile Include="SegmentMotionBU.cpp" />
-    <ClCompile Include="SegmentMotionDiff.cpp" />
     <ClCompile Include="main.cpp" />
-    <ClCompile Include="SegmentMotionGMM.cpp" />
-    <ClCompile Include="SegmentMotionMinMax.cpp" />
-    <ClCompile Include="ViBe.cpp" />
-    <ClCompile Include="ViBeDemo.cpp" />
+    <ClCompile Include="SegmentMotionMeanFilter.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="SegmentMotion1G.h" />
     <ClInclude Include="SegmentMotionBase.h" />
-    <ClInclude Include="SegmentMotionBU.h" />
-    <ClInclude Include="SegmentMotionDiff.h" />
-    <ClInclude Include="SegmentMotionGMM.h" />
-    <ClInclude Include="SegmentMotionMinMax.h" />
-    <ClInclude Include="ViBe.h" />
+    <ClInclude Include="SegmentMotionMeanFilter.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/lesson4/lesson4.vcxproj.filters
+++ b/lesson4/lesson4.vcxproj.filters
@@ -18,51 +18,18 @@
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="SegmentMotionDiff.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SegmentMotionBU.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SegmentMotionGMM.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="SegmentMotionBase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="SegmentMotionMinMax.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SegmentMotion1G.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ViBe.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ViBeDemo.cpp">
+    <ClCompile Include="SegmentMotionMeanFilter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="SegmentMotionDiff.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SegmentMotionBU.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SegmentMotionGMM.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="SegmentMotionBase.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="SegmentMotionMinMax.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SegmentMotion1G.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ViBe.h">
+    <ClInclude Include="SegmentMotionMeanFilter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/lesson4/main.cpp
+++ b/lesson4/main.cpp
@@ -1,44 +1,18 @@
-///@File: main.cpp
-///@Brief: Contains interface of console application for testing background
-///        subtraction algorithms
-///@Author: Vitaliy Baldeev
-///@Date: 01 October 2015
-
 #include <iostream>
 #include <memory>
 #include <list>
 
-#include "SegmentMotionDiff.h"
-#include "SegmentMotionBU.h"
-#include "SegmentMotionGMM.h"
-#include "SegmentMotion1G.h"
+#include "SegmentMotionMeanFilter.h"
 
-void ViBeDemo();
-
-int main()
+int main(int argc, char** argv)
 {
-    std::cout << "Select the algorithm: \n"
-        << "Diff  - Basic difference \n"
-        << "BU    - Basic difference with background updating \n"
-        << "GMM   - Gaussian mixture model algorithm \n"
-        << "MM    - MinMax algoruthm \n"
-        << "1G    - One Gaussian \n"
-        << "VB    - ViBe algorithm \n";
+  if (argc != 2) {
+    std::cerr << "Set name of input video" << std::endl;
+    return -1;
+  }
 
-    std::string algorithmName;
-    std::cin >> algorithmName;
+  SegmentMotionMeanFilter proc;
+  proc.Run(argv[1]);
 
-    std::unique_ptr<SegmentMotionBase> ptr(SegmentMotionBase::CreateAlgorithm(algorithmName));
-
-    if (ptr)
-    {
-        ptr->Run();
-    }
-    else
-    {
-        std::cout << "Run ViBe by default" << std::endl;
-        ViBeDemo();
-    }
-
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
Close #48.

Видео: https://yadi.sk/d/AnSEwyiwytqRx

## Метрики
### Recal

Точки внутри объекта (т.к. фон обновляется и из-за однородности объекта они помечаются как фон) дают спад метрики, после появления объекта. При более быстром движении объекта, ситуация лучше, чем при медленном.

![image](https://cloud.githubusercontent.com/assets/22376462/20427154/98dedd54-ad93-11e6-8745-ce37e88c8488.png)

### Precision

Так же имеется спад после начала движения объекта, он начинает оставлять за собой хвост.

![image](https://cloud.githubusercontent.com/assets/22376462/20427160/9f897c90-ad93-11e6-9ba7-cad066f3d84d.png)
### Specifity

Аналогична метрике Precision только с другой нормировкой. (TN примеров больше чем TP, и изменение TP и TN происходит пропорционально)

![image](https://cloud.githubusercontent.com/assets/22376462/20427169/a5498aa8-ad93-11e6-9868-b3a892628e04.png)

### False Positive Rate

Находится практически в нуле из-за большого количества TN примеров.

![image](https://cloud.githubusercontent.com/assets/22376462/20427173/ad3ba962-ad93-11e6-893e-dd5a9155e7a0.png)

### False Negative Rate

Такое поведение объясняется "хвостом" объекта при движении.

![image](https://cloud.githubusercontent.com/assets/22376462/20427178/b2a827ae-ad93-11e6-8524-82b9b476a44e.png)

### Percentage of wrong Classifications

Процент маленький изза большого количества TN примеров. И зависит от хвоста и центра объекта.

![image](https://cloud.githubusercontent.com/assets/22376462/20427194/c2c47a66-ad93-11e6-89a9-8a3fda5a78c2.png)

### F-measure

Результат аналогичен Precision и Recall.

![image](https://cloud.githubusercontent.com/assets/22376462/20427198/c82b20cc-ad93-11e6-8fb3-056b3bc71dc0.png)


