### PR TITLE
3. Detect moving romb using 1G algorithm with background update Close #50

### DIFF
--- a/lesson4/SegmentMotion1G.cpp
+++ b/lesson4/SegmentMotion1G.cpp
@@ -13,93 +13,20 @@
 #include "opencv2\highgui\highgui.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-cv::Mat SegmentMotion1G::process(cv::VideoCapture& capture)
+cv::Mat SegmentMotion1G::process(cv::Mat& currentFrame)
 {
-    if (m_params.historySize == 0)
-    {
-        m_params.historySize = 1;
-    }
+	if (!m_algorithmPtr)
+	{
+		m_algorithmPtr = cv::createBackgroundSubtractorMOG2(m_params.historySize, m_params.T, false);
+		(*m_algorithmPtr).setNMixtures(1);
+		
+	}
 
-    cv::Mat frame;
+	cv::Mat result;
 
-    if (m_frameBuffer.size() < m_params.historySize)
-    {
-        while (m_frameBuffer.size() < m_params.historySize)
-        {
-            capture >> frame;
-            cv::cvtColor(frame, frame, CV_BGR2GRAY);
-            m_frameBuffer.push_back(frame);
-        }
-    }
-    if (m_frameBuffer.size() > m_params.historySize)
-    {
-        while (m_frameBuffer.size() > m_params.historySize)
-        {
-            m_frameBuffer.pop_front();
-        }
-    }
+	m_algorithmPtr->apply(currentFrame, result);
 
-    capture >> frame;
-    cv::cvtColor(frame, frame, CV_BGR2GRAY);
-    m_frameBuffer.pop_front();
-    m_frameBuffer.push_back(frame);
-
-    //Calculate m, sigma
-    m_mMat = cv::Mat_<float>(frame.rows, frame.cols, 0.0);
-    m_sigmaMat = cv::Mat_<float>(frame.rows, frame.cols, 0.0);
-
-
-    for (int i = 0; i < frame.rows; i++)
-    {
-        for (int j = 0; j < frame.cols; j++)
-        {
-            std::list<cv::Mat>::const_iterator pos;
-
-            int n = 0;
-            for (pos = m_frameBuffer.begin(); pos != m_frameBuffer.end(); pos++)
-            {
-                const float val = static_cast<float>((*pos).at<uchar>(i, j));
-                n++;
-
-                // Calculate m
-                float sum = 0;
-                for (int k = 1; k <= n; k++)
-                {
-                    sum = sum + val;
-                }
-                m_mMat(i, j) = 1 / n*sum;
-
-                //Calculate sigma
-                float sum1 = 0;
-                for (int k = 1; k <= n; k++)
-                {
-                    sum1 = sum1 + (val - 1 / n*sum)*(val - 1 / n*sum);
-                }
-
-                m_sigmaMat(i, j) = 1 / n*sum1;
-            }
-        }
-    }
-
-    // Detect foreground
-    cv::Mat result(frame.rows, frame.cols, CV_8UC1);
-    for (int i = 0; i < frame.rows; i++)
-    {
-        for (int j = 0; j < frame.cols; j++)
-        {
-            if ((abs(m_mMat(i, j) - static_cast<float>(frame.at<uchar>(i, j))) / m_sigmaMat(i, j)) >
-                static_cast<float>(m_params.T))
-            {
-                result.at<uchar>(i, j) = static_cast<uchar>(0);
-            }
-            else
-            {
-                result.at<uchar>(i, j) = static_cast<uchar>(255);
-            }
-        }
-    }
-
-    return result;
+	return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -108,9 +35,9 @@ void SegmentMotion1G::createGUI()
     const std::string windowName = GetName();
     cv::namedWindow(windowName);
 
-    m_params.historySize = 10;
-    m_params.T = 3;
+	m_params.historySize = 3*24;
+    m_params.T = 10;
 
-    cv::createTrackbar("History", windowName, reinterpret_cast<int*>(&m_params.historySize), 20);
-    cv::createTrackbar("T", windowName, &m_params.T, 20);
+    cv::createTrackbar("History", windowName, reinterpret_cast<int*>(&m_params.historySize), 1000);
+    cv::createTrackbar("T", windowName, &m_params.T, 255);
 }

--- a/lesson4/SegmentMotion1G.h
+++ b/lesson4/SegmentMotion1G.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     ///@see SegmentMotionBase::process
-    virtual cv::Mat process(cv::VideoCapture& capture) override;
+    virtual cv::Mat process(cv::Mat& currentFrame) override;
 
     ///@see SegmentMotionBase::createGUI
     virtual void createGUI() override;
@@ -42,13 +42,6 @@ protected:
 
     Params m_params;
 
-    ///@brief frame buffer
-    std::list<cv::Mat> m_frameBuffer;
-    ///@brief matrix of min value of each pixel for the history
-    cv::Mat_<float> m_mMat;
-    ///@brief matrix of max value of each pixel for the history
-    cv::Mat_<float> m_sigmaMat;
-
     ///@brief Pointer to OpenCV algorithm of background subtraction
-    //cv::Ptr<cv::BackgroundSubtractorMOG2> m_algorithmPtr;
+    cv::Ptr<cv::BackgroundSubtractorMOG2> m_algorithmPtr;
 };

--- a/lesson4/SegmentMotionBU.cpp
+++ b/lesson4/SegmentMotionBU.cpp
@@ -12,11 +12,8 @@
 #include "opencv2\highgui.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-cv::Mat SegmentMotionBU::process(cv::VideoCapture& capture)
+cv::Mat SegmentMotionBU::process(cv::Mat& currentFrame)
 {
-    cv::Mat currentFrame;
-    capture >> currentFrame;
-
     if (!m_prevBackgroundUpdated)
     {
         cv::cvtColor(currentFrame, m_prevBackground, CV_RGB2GRAY);

--- a/lesson4/SegmentMotionBU.h
+++ b/lesson4/SegmentMotionBU.h
@@ -30,7 +30,7 @@ public:
 
 protected:
     ///@see SegmentMotionBase::process
-    virtual cv::Mat process(cv::VideoCapture& capture) override;
+    virtual cv::Mat process(cv::Mat& currentFrame) override;
 
     ///@see SegmentMotionBase::createGUI
     virtual void createGUI() override;

--- a/lesson4/SegmentMotionBase.cpp
+++ b/lesson4/SegmentMotionBase.cpp
@@ -17,28 +17,55 @@
 #include "SegmentMotion1G.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-void SegmentMotionBase::Run()
+void SegmentMotionBase::Run(const std::string& videoName, const std::string& videoDetectedObject)
 {
-    cv::VideoCapture capture(0);
+    cv::VideoCapture capture(videoName);
+	cv::VideoWriter  videoOut;
+
+	int codec = CV_FOURCC('M', 'J', 'P', 'G');
+	double fps = 24.0;
+
+	videoOut.open(videoDetectedObject, codec, fps, {512, 512});
+
+	if (!videoOut.isOpened())
+	{
+		std::cerr << "Could not open the output video file for write\n";
+		exit(-1);
+	}
 
     if (!capture.isOpened())
     {
-        std::cerr << "Can not open the camera !" << std::endl;
+        std::cerr << "Can not open the video!" << std::endl;
         exit(-1);
     }
 
     createGUI();
 
+	cv::Mat frame;
+	cv::Mat image_write(frame.rows, frame.cols, CV_8UC3);
     while (true)
     {
-        m_foreground = process(capture);
-        cv::imshow(GetName(), m_foreground);
+		capture >> frame;
+		if (frame.empty())
+		{
+			break;
+		}
 
+		m_foreground = process(frame);
+		cv::imshow(GetName(), m_foreground);
+
+		cv::cvtColor(m_foreground, image_write, CV_GRAY2BGR);
+
+		videoOut.write(image_write);
+	
         if (cv::waitKey(1) >= 0)
         {
             break;
         }
     }
+
+	videoOut.release();
+	capture.release();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/lesson4/SegmentMotionBase.h
+++ b/lesson4/SegmentMotionBase.h
@@ -20,7 +20,7 @@ class SegmentMotionBase
 {
 public:
     ///@brief Launch demonstration
-    void Run();
+    void Run(const std::string& videoName, const std::string& videoDetectedObject);
 
         ///@brief Factory method
     static SegmentMotionBase* CreateAlgorithm(std::string& algorithmName);
@@ -44,7 +44,7 @@ protected:
 
     ///@brief Apply the algorthm of background subtraction
     ///@return the result binary image
-    virtual cv::Mat process(cv::VideoCapture& capture) 
+    virtual cv::Mat process(cv::Mat& frame)
     { 
         return cv::Mat();
     }

--- a/lesson4/SegmentMotionDiff.cpp
+++ b/lesson4/SegmentMotionDiff.cpp
@@ -10,12 +10,8 @@
 #include "opencv2\highgui.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-cv::Mat SegmentMotionDiff::process(cv::VideoCapture& capture)
+cv::Mat SegmentMotionDiff::process(cv::Mat& currentFrame)
 {
-    cv::Mat currentFrame;
-
-    capture >> currentFrame;
-
     if (!m_backgroundUpdated)
     {
         cv::cvtColor(currentFrame, m_background, CV_RGB2GRAY);

--- a/lesson4/SegmentMotionDiff.h
+++ b/lesson4/SegmentMotionDiff.h
@@ -30,7 +30,7 @@ public:
 
 protected:
     ///@see SegmentMotionBase::process
-    virtual cv::Mat process(cv::VideoCapture& capture) override;
+    virtual cv::Mat process(cv::Mat& currentFrame) override;
 
     ///@see SegmentMotionBase::createGUI
     virtual void createGUI() override;

--- a/lesson4/SegmentMotionGMM.cpp
+++ b/lesson4/SegmentMotionGMM.cpp
@@ -12,15 +12,12 @@
 #include "opencv2\highgui.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
-cv::Mat SegmentMotionGMM::process(cv::VideoCapture& capture)
+cv::Mat SegmentMotionGMM::process(cv::Mat& currentFrame)
 {
     if(!m_algorithmPtr)
     {
         m_algorithmPtr = cv::createBackgroundSubtractorMOG2();
     }
-
-    cv::Mat currentFrame;
-    capture >> currentFrame;
 
     cv::Mat result;
     m_algorithmPtr->apply(currentFrame, result);

--- a/lesson4/SegmentMotionGMM.h
+++ b/lesson4/SegmentMotionGMM.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     ///@see SegmentMotionBase::process
-    virtual cv::Mat process(cv::VideoCapture& capture) override;
+    virtual cv::Mat process(cv::Mat& currentFrame) override;
 
     ///@see SegmentMotionBase::createGUI
     virtual void createGUI() override;

--- a/lesson4/SegmentMotionMinMax.cpp
+++ b/lesson4/SegmentMotionMinMax.cpp
@@ -12,21 +12,18 @@
 #include "SegmentMotionMinMax.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-cv::Mat SegmentMotionMinMax::process(cv::VideoCapture& capture)
+cv::Mat SegmentMotionMinMax::process(cv::Mat& frame)
 {
     if (m_params.historySize == 0)
     {
         m_params.historySize = 1;
     }
 
-    cv::Mat frame;
-
     if (m_frameBuffer.size() < m_params.historySize)
     {
+		cv::cvtColor(frame, frame, CV_BGR2GRAY);
         while (m_frameBuffer.size() < m_params.historySize)
         {
-            capture >> frame;
-            cv::cvtColor(frame, frame, CV_BGR2GRAY);
             m_frameBuffer.push_back(frame);
         }
     }
@@ -38,8 +35,7 @@ cv::Mat SegmentMotionMinMax::process(cv::VideoCapture& capture)
         }
     }
 
-    capture >> frame;
-    cv::cvtColor(frame, frame, CV_BGR2GRAY);
+    //cv::cvtColor(frame, frame, CV_BGR2GRAY);
     m_frameBuffer.pop_front();
     m_frameBuffer.push_back(frame);
 

--- a/lesson4/SegmentMotionMinMax.h
+++ b/lesson4/SegmentMotionMinMax.h
@@ -26,7 +26,7 @@ public:
 
 protected:
     ///@see SegmentMotionBase::process
-    virtual cv::Mat process(cv::VideoCapture& capture) override;
+    virtual cv::Mat process(cv::Mat& frame) override;
 
     ///@see SegmentMotionBase::createGUI
     virtual void createGUI() override;

--- a/lesson4/drawGraphics.m
+++ b/lesson4/drawGraphics.m
@@ -1,0 +1,36 @@
+clear
+clc
+close all
+
+fileName = './1G/measures.txt';
+path = './1G/';
+
+flageWritingImages = 1;
+
+fId = fopen(fileName, 'rt');
+
+if fId == -1 
+    error('File is not opened'); 
+end 
+
+numFrames = 24*23;
+numMetrics = 7;
+
+[value, ~] = fscanf(fId,'%d %f %f %f %f %f %f %f\n', [(numMetrics + 1) numFrames]);
+
+fclose(fId);
+
+metrics_names = {'F-measure', 'Precision', 'Recall', 'Specificity','False Positive Rate','False Negative Rate', 'Percentage of Wrong Classifications'};
+for i = 1:numMetrics
+    f = figure();
+    hold on
+    grid on
+    xlabel('# frame')
+    ylabel(metrics_names(i))
+    title(metrics_names(i))
+    plot(value(1,:), value((i + 1),:));
+    axis([0 (numFrames + 10) (min(value((i + 1),:)) - 0.1) (max(value((i + 1),:)) + 0.1)]);
+    if(flageWritingImages == 1)
+        print(f, '-dpng', [path char(metrics_names(i))]);
+    end
+end

--- a/lesson4/formVideo.m
+++ b/lesson4/formVideo.m
@@ -1,0 +1,84 @@
+clear
+clc
+close all
+
+flageWritingImages = 0;
+
+num_images = 480;
+num_images_without_object = 24*3;
+
+videoName = './1G/ImageWithObject.avi';
+
+videoObjectName = './1G/object.avi';
+
+radius_step = 0.4;
+angle_step = 0.05;
+
+im = imread('./1G/Rostislav.png');
+im_object = imread('./1G/romb.png');
+%im_object = rgb2gray(im_object);
+
+path_im_object = './1G/image with object/';
+path_object = './1G/object/';
+
+figure()
+imshow(im);
+title('Исходное изображение')
+
+figure()
+imshow(im_object);
+title('Изображение объекта')
+
+[M N ~] = size(im);
+[M_Object N_Object ~] = size(im_object);
+
+radius = 0;
+angle = 0;
+
+im_with_object = im;
+im_segm_object = zeros(M, N, 3);
+
+writer = avifile(videoName, 'compression', 'None', 'fps', 24);
+
+writerObject = avifile(videoObjectName, 'compression', 'None', 'fps', 24);
+
+for i = 1:num_images_without_object
+    writer = addframe(writer, uint8(im_with_object));
+    writerObject = addframe(writerObject, uint8(im_segm_object));
+    
+    if(flageWritingImages == 1)
+        imwrite(uint8(im_with_object), [path_im_object int2str(i) '.bmp'], 'bmp');
+        imwrite(uint8(im_segm_object), [path_object int2str(i) '_object.bmp'], 'bmp');
+    end
+end
+
+for i = (num_images_without_object + 1):(num_images + num_images_without_object)
+    im_with_object = im;
+    im_segm_object = zeros(M, N, 3);
+    
+    x = round(radius * cos(angle) + M / 2);
+    y = round(radius * sin(angle) + N / 2);
+    
+    for j = 1:M_Object
+        for k = 1:N_Object
+            if ( sum(im_object(j, k, :) ~= 255) == 3 )
+                im_with_object(x + j, y + k, :) = im_object(j, k, :);
+                im_segm_object(x + j, y + k, :) = 255;
+            end
+        end
+    end
+    
+    writer = addframe(writer, uint8(im_with_object)); 
+    writerObject = addframe(writerObject, uint8(im_segm_object));
+    
+    if flageWritingImages == 1
+        imwrite(uint8(im_with_object), [path_im_object int2str(i) '.bmp'], 'bmp');
+        imwrite(uint8(im_segm_object), [path_object int2str(i) '_object.bmp'], 'bmp');
+    end
+
+    radius = radius + radius_step;
+    angle = angle + angle_step;
+end
+
+writer = close(writer);
+writerObject = close(writerObject);

--- a/lesson4/main.cpp
+++ b/lesson4/main.cpp
@@ -5,18 +5,157 @@
 ///@Date: 01 October 2015
 
 #include <iostream>
+#include <fstream>
 #include <memory>
 #include <list>
+
+#include "opencv2\video\video.hpp"
+#include "opencv2\highgui\highgui.hpp"
 
 #include "SegmentMotionDiff.h"
 #include "SegmentMotionBU.h"
 #include "SegmentMotionGMM.h"
 #include "SegmentMotion1G.h"
 
+void wrFile(std::vector<double>& obj, const std::string& fileName, int mode, const std::string& mess)
+{
+	std::ofstream out(fileName, mode);
+	if (!out)
+	{
+		std::cout << "Cannot open file.\n";
+	}
+	out << mess + " ";
+	for (const auto& val : obj)
+	{
+		out << val << " ";
+	}
+	out << std::endl;
+
+	out.close();
+}
+
+//output: [0] - F;[1] - Precision;[2] - Recall;[3] - Specificity;[4] - False Positive Rate;
+//[5] - False Negative Rate;[6] - Percentage of Wrong Classifications;
+std::vector<double> F_Measure(cv::Mat& accurImage, cv::Mat& approxImage)
+{
+	std::vector<double> result(7, 0);
+
+	double TP, TN, FP, FN;
+
+	double whitePixelAccurIm = 0;
+	double whitePixelAppIm = 0;
+	FP = 0;
+	FN = 0;
+	TP = 0;
+	TN = 0;
+	for (int i = 0; i < accurImage.rows; ++i)
+	{
+		for (int j = 0; j < accurImage.cols; ++j)
+		{
+			if ((accurImage.at<cv::Vec3b>(i, j)[2] == 255) && ((accurImage.at<cv::Vec3b>(i, j)[1] == 255)) && ((accurImage.at<cv::Vec3b>(i, j)[0] == 255)))
+			{
+				whitePixelAccurIm++;
+				if ((approxImage.at<cv::Vec3b>(i, j)[2] == 255) && ((approxImage.at<cv::Vec3b>(i, j)[1] == 255)) && ((approxImage.at<cv::Vec3b>(i, j)[0] == 255)))
+				{
+					TP++;
+				}
+			}
+			if ((accurImage.at<cv::Vec3b>(i, j)[2] == 0) && ((accurImage.at<cv::Vec3b>(i, j)[1] == 0)) && ((accurImage.at<cv::Vec3b>(i, j)[0] == 0)))
+			{
+				if ((approxImage.at<cv::Vec3b>(i, j)[2] == 0) && ((approxImage.at<cv::Vec3b>(i, j)[1] == 0)) && ((approxImage.at<cv::Vec3b>(i, j)[0] == 0)))
+				{
+					TN++;
+				}
+			}
+			if ((approxImage.at<cv::Vec3b>(i, j)[2] == 255) && ((approxImage.at<cv::Vec3b>(i, j)[1] == 255)) && ((approxImage.at<cv::Vec3b>(i, j)[0] == 255)))
+			{
+				whitePixelAppIm++;
+			}
+		}
+	}
+	FN = whitePixelAccurIm - TP;
+	FP = whitePixelAppIm - TP;
+
+	if ((TP + FP) != 0)
+	{
+		result[1] = TP / (TP + FP);
+	}
+	if ((TP + FN) != 0)
+	{
+		result[2] = TP / (TP + FN);
+		result[5] = FN / (TP + FN);
+	}
+	if ((TN + FP) != 0)
+	{
+		result[3] = TN / (TN + FP);
+		result[4] = FP / (TN + FP);
+	}
+	if ((result[2] != 0) || (result[1] != 0))
+	{
+		result[0] = 2 * result[1] * result[2] / (result[1] + result[2]);
+	}
+	if ((TP + FN + FP + TN) != 0)
+	{
+		result[6] = 100 * (FN + FP) / (TP + FN + FP + TN);
+	}
+
+	return result;
+}
+
+void metricCalculation(const std::string& videoObject, const std::string& videoDetectedObject, const std::string& path)
+{
+	cv::VideoCapture capture(videoObject);
+	cv::VideoCapture captureObject(videoDetectedObject);
+
+	if ((!capture.isOpened()) || (!captureObject.isOpened()))
+	{
+		std::cerr << "Can not open the video!" << std::endl;
+		exit(-1);
+	}
+
+	cv::Mat frame;
+	cv::Mat frameObject;
+
+	int i = 0;
+	while (true)
+	{
+		i++;
+		capture >> frame;
+		captureObject >> frameObject;
+
+		if ((frame.empty()) || (frameObject.empty()))
+		{
+			break;
+		}
+
+		std::vector<double> eval = F_Measure(frame, frameObject);
+		wrFile(eval, std::string(path + "measures.txt"), std::ios::app, std::to_string(i));
+	}
+	captureObject.release();
+	capture.release();
+}
+
 void ViBeDemo();
 
-int main()
+int main(int argc, char** argv)
 {
+	cv::CommandLineParser parser(argc, argv, "{ help h                |                          | }"
+		                                     "{ @input_video          | ./1G/ImageWithObject.avi | }"
+		                                     "{ @input_object_video   | ./1G/object.avi          | }"
+	                                         "{ @output_path          | ./1G/                    | }");
+
+	if (parser.has("help"))
+	{
+		parser.printMessage();
+		return 0;
+	}
+
+	const auto& fileName = parser.get<std::string>("@input_video");
+	const auto& fileNameObject = parser.get<std::string>("@input_object_video");
+	const auto& outputPath = parser.get<std::string>("@output_path");
+
+	const auto nameVideoDet = std::string(outputPath + "detectedObject.avi");
+
     std::cout << "Select the algorithm: \n"
         << "Diff  - Basic difference \n"
         << "BU    - Basic difference with background updating \n"
@@ -32,13 +171,15 @@ int main()
 
     if (ptr)
     {
-        ptr->Run();
+        ptr->Run(fileName, nameVideoDet);
     }
     else
     {
         std::cout << "Run ViBe by default" << std::endl;
         ViBeDemo();
     }
+
+	metricCalculation(fileNameObject, nameVideoDet, outputPath);
 
     return 0;
 }


### PR DESCRIPTION
# Исходное изображение
![rostislav](https://cloud.githubusercontent.com/assets/22372080/20440714/390f5e5a-add2-11e6-83ed-4ca250371296.png)
# Видео
Объект появляется с 3 секунды.
[Видео](https://yadi.sk/d/4eIbz6PEyvr5E)
# Метрики и их графики
## Recall
![recall](https://cloud.githubusercontent.com/assets/22372080/20440584/c98a0076-add1-11e6-82ec-c13d33fd200c.png)
При появлении объекта в форме ромба происходит спад данной метрики, так как точки внутри объекта помечаются как фон. Далее происходит постепенный рост, так как увеличивается число пикселей, правильно отнесенных к объекту
## Precision
![precision](https://cloud.githubusercontent.com/assets/22372080/20440595/d47862f2-add1-11e6-839d-3f635de7d277.png)
Метрика колеблется, так как при движении объекта остается маленький след.
## Specificity
![specificity](https://cloud.githubusercontent.com/assets/22372080/20440669/146ff488-add2-11e6-9979-bec777b76d21.png)
Так как практически нет точек, которые ложно отнесены к объекту, то данная метрика всегда равна 1.
## False Positive Rate
![false positive rate](https://cloud.githubusercontent.com/assets/22372080/20440615/e204af48-add1-11e6-98c5-ff4831d9706a.png)
Противоположна предыдущей метрике.
## False Negative Rate
![false negative rate](https://cloud.githubusercontent.com/assets/22372080/20440627/ece14f16-add1-11e6-8e50-7495a84a6081.png)
Данная метрика ведет себя так, потому что за объектом остается маленький след. Она спадает, так как увеличивается число  пикселей, правильно отнесенных к объекту.
## Percentage of Wrong Classifications
![percentage of wrong classifications](https://cloud.githubusercontent.com/assets/22372080/20440647/fd667578-add1-11e6-80e8-4f274fc1db51.png)
Так как FP мало, а TN увеличивается.
## F-measure
![f-measure](https://cloud.githubusercontent.com/assets/22372080/20440655/07482168-add2-11e6-8ae0-2ecdf0a631af.png)
Среднее гармоническое величин Precision и Recall.


